### PR TITLE
Catch FileSkipComment exception

### DIFF
--- a/pyls_isort/plugin.py
+++ b/pyls_isort/plugin.py
@@ -12,11 +12,15 @@ try:
 
 except ImportError:
     # isort=>5
-    from isort import code
+    from isort import code, exceptions
     from isort.settings import Config
 
     def isort_sort(source, settings_path):
-        return code(source, config=Config(settings_path=settings_path))
+        try:
+            source = code(source, config=Config(settings_path=settings_path))
+        except exceptions.FileSkipComment:
+            pass
+        return source
 
 
 from pyls import hookimpl


### PR DESCRIPTION
When the comment `# isort:skip_file` is present in the document I always got an error message from [lsp-mode](https://github.com/emacs-lsp/lsp-mode) (Emacs package). 

```
Error: (error "isort.exceptions.FileSkipComment: Passed in content contains an file skip comment and was skipped.")
```

This PR catches this exception and returns input source unchanged, so that e.g. yapf can continue to format the rest of the document. 